### PR TITLE
Pre-Worlds Scouting Updates

### DIFF
--- a/apps/api/src/lib/telemetry.ts
+++ b/apps/api/src/lib/telemetry.ts
@@ -62,7 +62,23 @@ export function trackAuthEvent(event: AuthEventType, properties?: Record<string,
 
 /** Track an exception with optional custom properties. */
 export function trackException(error: Error, properties?: Record<string, string>): void {
-  client?.trackException({ exception: error, properties });
+  // Surface Prisma error codes as telemetry properties so they show up in
+  // Application Insights alongside the operation context.
+  const errRecord = error as unknown as Record<string, unknown>;
+  const prismaCode = typeof errRecord.code === 'string' ? errRecord.code : undefined;
+  const enriched: Record<string, string> | undefined =
+    prismaCode !== undefined ? { ...(properties ?? {}), prismaCode } : properties;
+
+  client?.trackException({ exception: error, properties: enriched });
+
+  // In non-production environments, echo the error to stderr so developers
+  // running `pnpm dev` can diagnose failures without needing Application
+  // Insights. Production keeps quiet to avoid leaking internals to logs.
+  if (process.env.NODE_ENV !== 'production') {
+    const context = enriched ? ` ${JSON.stringify(enriched)}` : '';
+    // eslint-disable-next-line no-console
+    console.error(`[trackException]${context} ${error.stack ?? error.message}`);
+  }
 }
 
 /** Returns true if the Application Insights client is initialized. */

--- a/apps/web/app/scouting/page.tsx
+++ b/apps/web/app/scouting/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, Suspense } from 'react';
+import { useMemo, useState, Suspense } from 'react';
 import Link from 'next/link';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { InfoBox } from '@/components/info-box';
@@ -18,11 +18,13 @@ import type {
   ScoutingFieldDefinition,
   GameMetricDefinition,
   ScoutingStatus,
+  TeamRankAnalysis,
 } from '@allianceops/shared';
 import type { EnrichedTeam } from '@/lib/types';
-import { TeamCard } from '@/components/team-card';
+import type { EnrichedTeam as PicklistEnrichedTeam } from '@/components/picklist/types';
 import { ScoutingForm } from '@/components/scouting/scouting-form';
 import { ScoutingTeamList } from '@/components/scouting/scouting-team-list';
+import { TeamDetailModal } from '@/components/picklist/team-detail-modal';
 
 interface TBAMatch {
   key: string;
@@ -132,6 +134,30 @@ function ScoutingContent() {
 
   const selectedTeamData = selectedTeam ? epaMap.get(selectedTeam) : null;
 
+  // Team records (wins/losses/ties) computed from qual matches — used for the team detail modal.
+  const teamRecords = useMemo(() => {
+    const records = new Map<number, { wins: number; losses: number; ties: number }>();
+    if (!matches) return records;
+    const qualMatches = matches.filter((m) => m.comp_level === 'qm');
+    for (const m of qualMatches) {
+      for (const teamKey of [...m.alliances.red.team_keys, ...m.alliances.blue.team_keys]) {
+        const num = parseInt(teamKey.replace('frc', ''), 10);
+        if (!records.has(num)) records.set(num, { wins: 0, losses: 0, ties: 0 });
+        const rec = records.get(num)!;
+        const isRed = m.alliances.red.team_keys.includes(teamKey);
+        if (m.winning_alliance === 'red' && isRed) rec.wins++;
+        else if (m.winning_alliance === 'blue' && !isRed) rec.wins++;
+        else if (m.winning_alliance === '') rec.ties++;
+        else if (m.alliances.red.score >= 0) rec.losses++;
+      }
+    }
+    return records;
+  }, [matches]);
+
+  const emptyRankAnalysisMap = useMemo(() => new Map<string, TeamRankAnalysis>(), []);
+
+  const [modalTeam, setModalTeam] = useState<number | null>(null);
+
   return (
     <PageGuard
       condition={eventKey}
@@ -166,7 +192,7 @@ function ScoutingContent() {
         ) : (
           /* Individual team scouting view */
           <div className="space-y-4">
-            {/* Back button + save */}
+            {/* Back button + clickable team header + save */}
             <div className="flex items-center gap-4">
               <Link
                 href="/scouting/"
@@ -183,14 +209,35 @@ function ScoutingContent() {
                 </svg>
                 All Teams
               </Link>
-              <span className="text-lg font-bold">
-                {selectedTeam}
-                {selectedTeamData?.nickname && (
-                  <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
-                    {selectedTeamData.nickname}
-                  </span>
-                )}
-              </span>
+              <button
+                type="button"
+                onClick={() => setModalTeam(selectedTeam)}
+                aria-label={`View team ${selectedTeam} details`}
+                className="group inline-flex items-center gap-2 text-left rounded-md px-1 -mx-1 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              >
+                <span className="text-lg font-bold">
+                  {selectedTeam}
+                  {selectedTeamData?.nickname && (
+                    <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
+                      {selectedTeamData.nickname}
+                    </span>
+                  )}
+                </span>
+                <svg
+                  className="h-4 w-4 text-gray-400 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M13 7h6m0 0v6m0-6L10 16M7 7H5a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-2"
+                  />
+                </svg>
+              </button>
               <div className="ml-auto">
                 <SaveComboButton
                   canEdit={canEdit}
@@ -205,99 +252,90 @@ function ScoutingContent() {
               </div>
             </div>
 
-            {/* Status + last updated row */}
-            <div className="flex flex-wrap items-center gap-4 rounded-lg border border-gray-200 dark:border-gray-700 px-4 py-3">
-              <div className="flex items-center gap-2">
-                <label
-                  htmlFor="scouting-status"
-                  className="text-sm font-medium text-gray-700 dark:text-gray-300"
-                >
-                  Status
-                </label>
-                <select
-                  id="scouting-status"
-                  value={scoutingStatus}
-                  disabled={!canEdit}
-                  onChange={(e) =>
-                    updateScoutingStatus(e.target.value as ScoutingStatus)
-                  }
-                  className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm disabled:opacity-50"
-                >
-                  {SCOUTING_STATUS_OPTIONS.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              {noteUpdatedAt && (
-                <div className="ml-auto text-xs text-gray-500 dark:text-gray-400">
-                  Last updated{' '}
-                  {new Date(noteUpdatedAt).toLocaleString()}
-                  {noteUpdatedByName && (
-                    <span> by {noteUpdatedByName}</span>
-                  )}
-                </div>
-              )}
-            </div>
-
             {noteLoading ? (
               <LoadingSpinner />
             ) : (
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                {/* Left: Team Card */}
-                <div>
-                  <TeamCard
-                    teamKey={`frc${selectedTeam}`}
-                    epaMap={epaMap}
-                    epaRank={epaRankMap.get(selectedTeam)}
-                    metrics={cardMetrics}
-                    defaultExpanded
-                  />
-                </div>
+              <div className="space-y-5">
+                {/* Import from past event prompt */}
+                {pastNoteChecked && pastNote && !dirty && !notes && (
+                  <div className="rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/30 px-3 py-2.5 flex items-center justify-between gap-3">
+                    <div className="text-sm text-blue-800 dark:text-blue-200">
+                      <span className="font-medium">Notes from {pastNote.eventKey}</span>
+                      {' — '}
+                      import as a starting baseline?
+                    </div>
+                    <button
+                      type="button"
+                      onClick={importPastNote}
+                      className="shrink-0 rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 transition-colors"
+                    >
+                      Import
+                    </button>
+                  </div>
+                )}
 
-                {/* Right: Scouting Form */}
-                <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-                  <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-                    Scouting Analysis
-                  </h3>
-
-                  {/* Import from past event prompt */}
-                  {pastNoteChecked && pastNote && !dirty && !notes && (
-                    <div className="mb-4 rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/30 px-3 py-2.5 flex items-center justify-between gap-3">
-                      <div className="text-sm text-blue-800 dark:text-blue-200">
-                        <span className="font-medium">Notes from {pastNote.eventKey}</span>
-                        {' — '}
-                        import as a starting baseline?
-                      </div>
-                      <button
-                        type="button"
-                        onClick={importPastNote}
-                        className="shrink-0 rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700 transition-colors"
-                      >
-                        Import
-                      </button>
+                {/* Status + last-updated row (above Notes) */}
+                <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
+                  <div className="flex items-center gap-2">
+                    <label
+                      htmlFor="scouting-status"
+                      className="text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      Status
+                    </label>
+                    <select
+                      id="scouting-status"
+                      value={scoutingStatus}
+                      disabled={!canEdit}
+                      onChange={(e) =>
+                        updateScoutingStatus(e.target.value as ScoutingStatus)
+                      }
+                      className="rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm disabled:opacity-50"
+                    >
+                      {SCOUTING_STATUS_OPTIONS.map((opt) => (
+                        <option key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {noteUpdatedAt && (
+                    <div className="sm:ml-auto text-xs text-gray-500 dark:text-gray-400">
+                      Last updated {new Date(noteUpdatedAt).toLocaleString()}
+                      {noteUpdatedByName && <span> by {noteUpdatedByName}</span>}
                     </div>
                   )}
-
-                  <ScoutingForm
-                    fields={scoutingFields}
-                    notes={notes}
-                    data={data}
-                    disabled={!canEdit}
-                    onNotesChange={updateNotes}
-                    onFieldChange={updateField}
-                    onPerMatchChange={updatePerMatchValue}
-                    matches={matches ?? []}
-                    targetTeamNumber={selectedTeam}
-                    tags={tags}
-                    allTags={allTags}
-                    onTagsChange={updateTags}
-                  />
                 </div>
+
+                <ScoutingForm
+                  fields={scoutingFields}
+                  notes={notes}
+                  data={data}
+                  disabled={!canEdit}
+                  onNotesChange={updateNotes}
+                  onFieldChange={updateField}
+                  onPerMatchChange={updatePerMatchValue}
+                  matches={matches ?? []}
+                  targetTeamNumber={selectedTeam}
+                  tags={tags}
+                  allTags={allTags}
+                  onTagsChange={updateTags}
+                />
               </div>
             )}
           </div>
+        )}
+
+        {modalTeam !== null && (
+          <TeamDetailModal
+            teamNumber={modalTeam}
+            epaMap={epaMap as Map<number, PicklistEnrichedTeam>}
+            epaRankMap={epaRankMap}
+            rankAnalysisMap={emptyRankAnalysisMap}
+            teamRecords={teamRecords}
+            cardMetrics={cardMetrics}
+            onClose={() => setModalTeam(null)}
+          />
         )}
 
         <SaveStatusBar status={saveStatus} lastSavedAt={lastSavedAt} />

--- a/apps/web/app/scouting/page.tsx
+++ b/apps/web/app/scouting/page.tsx
@@ -24,6 +24,19 @@ import { TeamCard } from '@/components/team-card';
 import { ScoutingForm } from '@/components/scouting/scouting-form';
 import { ScoutingTeamList } from '@/components/scouting/scouting-team-list';
 
+interface TBAMatch {
+  key: string;
+  comp_level: string;
+  set_number: number;
+  match_number: number;
+  alliances: {
+    red: { team_keys: string[]; score: number };
+    blue: { team_keys: string[]; score: number };
+  };
+  time: number | null;
+  winning_alliance: string;
+}
+
 function ScoutingContent() {
   const { eventKey, year } = useEventSetup();
   const { activeTeam } = useAuth();
@@ -49,6 +62,10 @@ function ScoutingContent() {
     eventKey ? `event/${eventKey}/teams` : null,
   );
 
+  const { data: matches } = useApi<TBAMatch[]>(
+    eventKey ? `event/${eventKey}/matches` : null,
+  );
+
   const {
     canEdit,
     user,
@@ -58,6 +75,7 @@ function ScoutingContent() {
     scoutingStatus,
     updateNotes,
     updateField,
+    updatePerMatchValue,
     updateScoutingStatus,
     tags,
     allTags,
@@ -269,6 +287,9 @@ function ScoutingContent() {
                     disabled={!canEdit}
                     onNotesChange={updateNotes}
                     onFieldChange={updateField}
+                    onPerMatchChange={updatePerMatchValue}
+                    matches={matches ?? []}
+                    targetTeamNumber={selectedTeam}
                     tags={tags}
                     allTags={allTags}
                     onTagsChange={updateTags}

--- a/apps/web/components/app-header.tsx
+++ b/apps/web/components/app-header.tsx
@@ -176,7 +176,7 @@ export function AppHeader() {
 
         {/* Desktop: centered controls */}
         {showControls && (
-          <div className="hidden md:flex items-center justify-center min-w-0 flex-1">
+          <div className="hidden lg:flex items-center justify-center min-w-0 flex-1">
             <GlobalControls />
           </div>
         )}
@@ -184,7 +184,7 @@ export function AppHeader() {
         {/* Desktop: nav + user menu together; Mobile: hamburger */}
         <div className="flex items-center gap-4 shrink-0">
           {showControls && (
-            <div className="hidden md:flex items-center gap-4">
+            <div className="hidden lg:flex items-center gap-4">
               <NavLinks />
               {user ? (
                 <UserMenu displayLabel={userLabel} />
@@ -198,7 +198,7 @@ export function AppHeader() {
           {showControls && (
             <button
               onClick={() => setMobileOpen((o) => !o)}
-              className="md:hidden p-1.5 text-gray-600 dark:text-gray-300 hover:text-primary-600"
+              className="lg:hidden p-1.5 text-gray-600 dark:text-gray-300 hover:text-primary-600"
               aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
             >
               {mobileOpen ? (
@@ -227,7 +227,7 @@ export function AppHeader() {
 
       {/* Mobile dropdown panel */}
       {mobileOpen && showControls && (
-        <div className="md:hidden border-t border-gray-200 dark:border-gray-800 px-4 py-4 space-y-4">
+        <div className="lg:hidden border-t border-gray-200 dark:border-gray-800 px-4 py-4 space-y-4">
           <GlobalControls />
           <NavLinks vertical onNavigate={() => setMobileOpen(false)} />
           <hr className="border-gray-200 dark:border-gray-700" />

--- a/apps/web/components/scouting/per-match-table.tsx
+++ b/apps/web/components/scouting/per-match-table.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { ScoutingFieldDefinition } from '@allianceops/shared';
+import { matchLabel, sortMatches } from '@/lib/match-utils';
+
+interface TBAMatchLike {
+    key: string;
+    comp_level: string;
+    set_number?: number;
+    match_number: number;
+    alliances: {
+        red: { team_keys: string[] };
+        blue: { team_keys: string[] };
+    };
+}
+
+export function PerMatchTable({
+    fields,
+    matches,
+    targetTeamNumber,
+    data,
+    disabled,
+    onChange,
+}: {
+    fields: ScoutingFieldDefinition[];
+    matches: TBAMatchLike[];
+    targetTeamNumber: number;
+    data: Record<string, unknown>;
+    disabled: boolean;
+    onChange: (fieldKey: string, matchKey: string, value: number | null) => void;
+}) {
+    const teamKey = `frc${targetTeamNumber}`;
+
+    const rows = useMemo(() => {
+        const filtered = matches.filter(
+            (m) =>
+                m.alliances.red.team_keys.includes(teamKey) ||
+                m.alliances.blue.team_keys.includes(teamKey),
+        );
+        return sortMatches(filtered);
+    }, [matches, teamKey]);
+
+    if (fields.length === 0) return null;
+
+    if (rows.length === 0) {
+        return (
+            <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+                No matches scheduled for team {targetTeamNumber} yet.
+            </p>
+        );
+    }
+
+    const getCellValue = (fieldKey: string, matchKey: string): number | '' => {
+        const raw = data[fieldKey];
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return '';
+        const v = (raw as Record<string, unknown>)[matchKey];
+        return typeof v === 'number' && Number.isFinite(v) ? v : '';
+    };
+
+    return (
+        <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+                <thead>
+                    <tr className="border-b border-gray-200 dark:border-gray-700">
+                        <th className="px-2 py-1.5 text-left font-medium text-gray-700 dark:text-gray-300">
+                            Match
+                        </th>
+                        {fields.map((f) => (
+                            <th
+                                key={f.key}
+                                className="px-2 py-1.5 text-left font-medium text-gray-700 dark:text-gray-300"
+                                title={f.description}
+                            >
+                                {f.label}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map((match) => {
+                        const alliance = match.alliances.red.team_keys.includes(teamKey) ? 'red' : 'blue';
+                        return (
+                            <tr
+                                key={match.key}
+                                className="border-b border-gray-100 dark:border-gray-800 last:border-b-0"
+                            >
+                                <td className="px-2 py-1.5 whitespace-nowrap">
+                                    <span
+                                        className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 ${alliance === 'red' ? 'bg-red-500' : 'bg-blue-500'}`}
+                                        aria-label={alliance}
+                                    />
+                                    {matchLabel(match)}
+                                </td>
+                                {fields.map((f) => {
+                                    const current = getCellValue(f.key, match.key);
+                                    return (
+                                        <td key={f.key} className="px-2 py-1.5">
+                                            <input
+                                                type="number"
+                                                value={current}
+                                                disabled={disabled}
+                                                onChange={(e) => {
+                                                    const raw = e.target.value;
+                                                    onChange(
+                                                        f.key,
+                                                        match.key,
+                                                        raw === '' ? null : Number(raw),
+                                                    );
+                                                }}
+                                                className="w-20 rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-2 py-1 text-sm disabled:opacity-50"
+                                            />
+                                        </td>
+                                    );
+                                })}
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/apps/web/components/scouting/scouting-field.tsx
+++ b/apps/web/components/scouting/scouting-field.tsx
@@ -19,7 +19,9 @@ export function ScoutingField({
   onChange: (value: unknown) => void;
 }) {
   switch (field.type) {
-    case 'number':
+    case 'number': {
+      const isReadOnly = field.readOnly === true;
+      const displayValue = typeof value === 'number' ? value : '';
       return (
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -28,13 +30,23 @@ export function ScoutingField({
           <FieldDescription text={field.description} />
           <input
             type="number"
-            value={typeof value === 'number' ? value : ''}
-            disabled={disabled}
-            onChange={(e) => onChange(e.target.value === '' ? null : Number(e.target.value))}
-            className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm disabled:opacity-50"
+            value={displayValue}
+            disabled={disabled || isReadOnly}
+            readOnly={isReadOnly}
+            onChange={(e) => {
+              if (isReadOnly) return;
+              onChange(e.target.value === '' ? null : Number(e.target.value));
+            }}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm disabled:opacity-50 read-only:bg-gray-100 dark:read-only:bg-gray-900 read-only:cursor-not-allowed"
           />
+          {isReadOnly && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 italic">
+              Automatically averaged from per-match entries
+            </p>
+          )}
         </div>
       );
+    }
 
     case 'boolean':
       return (

--- a/apps/web/components/scouting/scouting-form.tsx
+++ b/apps/web/components/scouting/scouting-form.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import type { ScoutingFieldDefinition } from '@allianceops/shared';
 import { ScoutingField } from './scouting-field';
+import { PerMatchTable } from './per-match-table';
 import { TagDropdown } from '../picklist/tag-filter-control';
 
 const CATEGORIES = ['general', 'auto', 'teleop', 'endgame'] as const;
@@ -14,6 +15,17 @@ const CATEGORY_LABELS: Record<string, string> = {
   endgame: 'Endgame',
 };
 
+interface TBAMatchLike {
+  key: string;
+  comp_level: string;
+  set_number?: number;
+  match_number: number;
+  alliances: {
+    red: { team_keys: string[] };
+    blue: { team_keys: string[] };
+  };
+}
+
 export function ScoutingForm({
   fields,
   notes,
@@ -21,6 +33,9 @@ export function ScoutingForm({
   disabled,
   onNotesChange,
   onFieldChange,
+  onPerMatchChange,
+  matches,
+  targetTeamNumber,
   tags,
   allTags,
   onTagsChange,
@@ -31,6 +46,9 @@ export function ScoutingForm({
   disabled: boolean;
   onNotesChange: (notes: string) => void;
   onFieldChange: (key: string, value: unknown) => void;
+  onPerMatchChange: (fieldKey: string, matchKey: string, value: number | null) => void;
+  matches: TBAMatchLike[];
+  targetTeamNumber: number;
   tags: string[];
   allTags: string[];
   onTagsChange: (tags: string[]) => void;
@@ -41,10 +59,15 @@ export function ScoutingForm({
     setCollapsed((prev) => ({ ...prev, [cat]: !prev[cat] }));
   };
 
+  // Per-match fields are rendered collectively in a dedicated table, not
+  // within their category sections.
+  const perMatchFields = fields.filter((f) => f.type === 'per-match-number');
+  const standardFields = fields.filter((f) => f.type !== 'per-match-number');
+
   const groupedFields = CATEGORIES.map((cat) => ({
     category: cat,
     label: CATEGORY_LABELS[cat],
-    fields: fields.filter((f) => f.category === cat),
+    fields: standardFields.filter((f) => f.category === cat),
   })).filter((g) => g.fields.length > 0);
 
   return (
@@ -140,6 +163,46 @@ export function ScoutingForm({
           )}
         </div>
       ))}
+
+      {/* Per-Match Observations */}
+      {perMatchFields.length > 0 && (
+        <div>
+          <button
+            type="button"
+            onClick={() => toggleSection('per-match')}
+            className="flex items-center gap-1.5 w-full text-left mb-2"
+          >
+            <svg
+              className={`h-3.5 w-3.5 text-gray-400 transition-transform shrink-0 ${collapsed['per-match'] ? '' : 'rotate-90'}`}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+            <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Per-Match Observations
+            </span>
+            <span className="text-xs text-gray-400">({perMatchFields.length})</span>
+          </button>
+          {!collapsed['per-match'] && (
+            <div className="pl-5">
+              <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                Enter values per match. Averages above update automatically.
+              </p>
+              <PerMatchTable
+                fields={perMatchFields}
+                matches={matches}
+                targetTeamNumber={targetTeamNumber}
+                data={data}
+                disabled={disabled}
+                onChange={onPerMatchChange}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/components/scouting/scouting-form.tsx
+++ b/apps/web/components/scouting/scouting-form.tsx
@@ -70,13 +70,36 @@ export function ScoutingForm({
     fields: standardFields.filter((f) => f.category === cat),
   })).filter((g) => g.fields.length > 0);
 
+  const allSectionKeys: string[] = [
+    'picklist',
+    ...groupedFields.map((g) => g.category),
+    ...(perMatchFields.length > 0 ? ['per-match'] : []),
+  ];
+  const allCollapsed = allSectionKeys.every((k) => collapsed[k]);
+  const toggleAll = () => {
+    if (allCollapsed) {
+      setCollapsed({});
+    } else {
+      setCollapsed(Object.fromEntries(allSectionKeys.map((k) => [k, true])));
+    }
+  };
+
   return (
     <div className="space-y-5">
       {/* Notes */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-          Notes
-        </label>
+        <div className="flex items-center justify-between mb-1">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Notes
+          </label>
+          <button
+            type="button"
+            onClick={toggleAll}
+            className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            {allCollapsed ? 'Expand all' : 'Collapse all'}
+          </button>
+        </div>
         <textarea
           value={notes}
           disabled={disabled}

--- a/apps/web/components/team-card.tsx
+++ b/apps/web/components/team-card.tsx
@@ -295,22 +295,37 @@ export function TeamCard({
                     {scoutingSummary.data && (
                       <div className="space-y-1">
                         {scoutingFields
+                          .filter((f) => f.showInTeamCard === true)
                           .filter((f) => {
                             const v = scoutingSummary.data[f.key];
                             if (v == null) return false;
                             if (Array.isArray(v)) return v.length > 0;
                             if (typeof v === 'string') return v.length > 0;
+                            // Defensive: never render raw objects (e.g. legacy
+                            // per-match maps written under an aggregate key).
+                            if (typeof v === 'object') return false;
                             return true;
                           })
                           .map((f) => {
                             const v = scoutingSummary.data[f.key];
-                            const display = Array.isArray(v) ? (v as string[]).join(', ') : String(v);
+                            let display: string;
+                            if (Array.isArray(v)) {
+                              display = (v as string[]).join(', ');
+                            } else if (typeof v === 'number') {
+                              display = Number.isInteger(v) ? String(v) : v.toFixed(1);
+                            } else {
+                              display = String(v);
+                            }
+                            const stacked = f.type === 'text';
                             return (
-                              <div key={f.key} className="flex gap-1.5">
+                              <div
+                                key={f.key}
+                                className={stacked ? 'flex flex-col' : 'flex gap-1.5'}
+                              >
                                 <span className="text-gray-500 dark:text-gray-400 shrink-0">
                                   {f.label}:
                                 </span>
-                                <span className="text-gray-700 dark:text-gray-200 font-medium">
+                                <span className="text-gray-700 dark:text-gray-200 font-medium whitespace-pre-wrap break-words">
                                   {display}
                                 </span>
                               </div>

--- a/apps/web/hooks/use-scouting-data.ts
+++ b/apps/web/hooks/use-scouting-data.ts
@@ -6,7 +6,14 @@ import { useAuth } from '@/components/use-auth';
 import { useSignalR } from '@/hooks/use-signalr';
 import { useAutosave } from '@/hooks/use-autosave';
 import { getApiBase } from '@/lib/api-base';
-import type { ScoutingEntry, ScoutingSummary, ScoutingStatus } from '@allianceops/shared';
+import { applyPerMatchCellChange, computePerMatchAverage } from '@/lib/per-match-scouting';
+import { getAdapter } from '@allianceops/shared';
+import type {
+  ScoutingEntry,
+  ScoutingFieldDefinition,
+  ScoutingSummary,
+  ScoutingStatus,
+} from '@allianceops/shared';
 
 export interface PastScoutingNote {
   eventKey: string;
@@ -222,6 +229,40 @@ export function useScoutingData(selectedTeamNumber: number | null) {
     setSaveStatus('dirty');
   }, []);
 
+  // --- Adapter scouting fields (for per-match aggregation lookup) ---
+  const scoutingFields = useMemo<ScoutingFieldDefinition[]>(() => {
+    try {
+      return getAdapter(year).scoutingFields ?? [];
+    } catch {
+      return [];
+    }
+  }, [year]);
+
+  const updatePerMatchValue = useCallback(
+    (fieldKey: string, matchKey: string, value: number | null) => {
+      setData((prev) => {
+        const nextMap = applyPerMatchCellChange(prev[fieldKey], matchKey, value);
+        const next: Record<string, unknown> = { ...prev, [fieldKey]: nextMap };
+
+        // Recompute the aggregate (if any) that derives from this field.
+        // When the per-match map is empty, the legacy aggregate value is
+        // preserved — see ADR 034.
+        const aggregateField = scoutingFields.find((f) => f.derivedFromKey === fieldKey);
+        if (aggregateField) {
+          const avg = computePerMatchAverage(nextMap);
+          if (avg !== null) {
+            next[aggregateField.key] = avg;
+          }
+        }
+
+        return next;
+      });
+      setDirty(true);
+      setSaveStatus('dirty');
+    },
+    [scoutingFields],
+  );
+
   const updateTags = useCallback((newTags: string[]) => {
     setTags(newTags);
     setTagsDirty(true);
@@ -401,6 +442,7 @@ export function useScoutingData(selectedTeamNumber: number | null) {
     scoutingStatus,
     updateNotes,
     updateField,
+    updatePerMatchValue,
     updateScoutingStatus,
     noteLoading,
     noteUpdatedAt,

--- a/apps/web/lib/__tests__/per-match-scouting.test.ts
+++ b/apps/web/lib/__tests__/per-match-scouting.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { applyPerMatchCellChange, computePerMatchAverage } from '../per-match-scouting';
+
+describe('computePerMatchAverage', () => {
+  it('returns null for an empty map', () => {
+    expect(computePerMatchAverage({})).toBeNull();
+  });
+
+  it('returns null when the map has no numeric values', () => {
+    expect(computePerMatchAverage({ a: 'x', b: null, c: undefined })).toBeNull();
+  });
+
+  it('averages a single numeric value', () => {
+    expect(computePerMatchAverage({ a: 7 })).toBe(7);
+  });
+
+  it('averages multiple numeric values', () => {
+    expect(computePerMatchAverage({ a: 4, b: 8 })).toBe(6);
+  });
+
+  it('rounds to two decimal places', () => {
+    expect(computePerMatchAverage({ a: 1, b: 2, c: 2 })).toBe(1.67);
+  });
+
+  it('ignores non-numeric entries', () => {
+    expect(computePerMatchAverage({ a: 10, b: 'x', c: null, d: 20 })).toBe(15);
+  });
+
+  it('ignores NaN and Infinity', () => {
+    expect(computePerMatchAverage({ a: 4, b: NaN, c: Infinity })).toBe(4);
+  });
+});
+
+describe('applyPerMatchCellChange', () => {
+  it('creates a new map when previous is not an object', () => {
+    expect(applyPerMatchCellChange(undefined, '2026misjo_qm1', 5)).toEqual({
+      '2026misjo_qm1': 5,
+    });
+  });
+
+  it('treats arrays as empty and replaces them', () => {
+    expect(applyPerMatchCellChange([], '2026misjo_qm1', 3)).toEqual({
+      '2026misjo_qm1': 3,
+    });
+  });
+
+  it('adds a new cell to an existing map', () => {
+    expect(applyPerMatchCellChange({ '2026misjo_qm1': 5 }, '2026misjo_qm2', 8)).toEqual({
+      '2026misjo_qm1': 5,
+      '2026misjo_qm2': 8,
+    });
+  });
+
+  it('overwrites an existing cell', () => {
+    expect(applyPerMatchCellChange({ '2026misjo_qm1': 5 }, '2026misjo_qm1', 9)).toEqual({
+      '2026misjo_qm1': 9,
+    });
+  });
+
+  it('removes a cell when value is null', () => {
+    expect(
+      applyPerMatchCellChange({ '2026misjo_qm1': 5, '2026misjo_qm2': 8 }, '2026misjo_qm1', null),
+    ).toEqual({
+      '2026misjo_qm2': 8,
+    });
+  });
+
+  it('removes a cell when value is NaN', () => {
+    expect(applyPerMatchCellChange({ '2026misjo_qm1': 5 }, '2026misjo_qm1', NaN)).toEqual({});
+  });
+
+  it('does not mutate the previous map', () => {
+    const prev = { '2026misjo_qm1': 5 };
+    const next = applyPerMatchCellChange(prev, '2026misjo_qm2', 7);
+    expect(prev).toEqual({ '2026misjo_qm1': 5 });
+    expect(next).not.toBe(prev);
+  });
+});

--- a/apps/web/lib/per-match-scouting.ts
+++ b/apps/web/lib/per-match-scouting.ts
@@ -1,0 +1,45 @@
+/**
+ * Utilities for the per-match scouting UI.
+ *
+ * Per-match numeric scouting fields store their values as a nested object
+ * keyed by TBA match key (e.g. `{ "2026misjo_qm12": 5 }`). The aggregate
+ * field that declares `derivedFromKey` against one of these per-match fields
+ * displays the average of the numeric entries; blanks are excluded.
+ */
+
+/**
+ * Compute the rounded-to-2-decimals average of the numeric values in a
+ * per-match map. Non-numeric/non-finite values are ignored. Returns `null`
+ * when there are no numeric values (callers should leave the aggregate
+ * unchanged in that case — see ADR 034).
+ */
+export function computePerMatchAverage(map: Record<string, unknown>): number | null {
+  const numericValues = Object.values(map).filter(
+    (v): v is number => typeof v === 'number' && Number.isFinite(v),
+  );
+  if (numericValues.length === 0) return null;
+  const sum = numericValues.reduce((acc, n) => acc + n, 0);
+  return Math.round((sum / numericValues.length) * 100) / 100;
+}
+
+/**
+ * Given a per-match field's current value (from `ScoutingNote.data[fieldKey]`),
+ * return an updated map reflecting the supplied cell change. Passing `null`
+ * or `NaN` removes the entry for that match.
+ */
+export function applyPerMatchCellChange(
+  previous: unknown,
+  matchKey: string,
+  value: number | null,
+): Record<string, unknown> {
+  const base =
+    previous && typeof previous === 'object' && !Array.isArray(previous)
+      ? { ...(previous as Record<string, unknown>) }
+      : {};
+  if (value === null || Number.isNaN(value)) {
+    delete base[matchKey];
+  } else {
+    base[matchKey] = value;
+  }
+  return base;
+}

--- a/docs/adr/034-per-match-scouting-entries.md
+++ b/docs/adr/034-per-match-scouting-entries.md
@@ -1,0 +1,56 @@
+# ADR 034: Per-Match Scouting Entries
+
+**Status**: Accepted
+**Date**: 2026-04-23
+
+## Context
+
+ADR 033 established `ScoutingNote` as an aggregate-per-team record with game-specific fields captured as a JSON blob keyed by `ScoutingFieldDefinition.key`. It explicitly deferred per-match granularity:
+
+> Per-match scouting entries: More granular but significantly more complex. Would require match selection UI, aggregation logic, and many more records. **Deferred as a future enhancement.**
+
+In practice, scouts were being asked to mentally average counts (fuel scored per match, etc.) across many qualification and playoff matches, which is error-prone. We needed a way to let students enter raw counts for each match the target team plays and have the aggregate update automatically — without changing the database schema or giving up the adapter-driven, season-agnostic field model.
+
+## Decision
+
+### Adapter-driven per-match field type
+
+Extend `ScoutingFieldDefinition` with:
+
+- A new `type` variant `'per-match-number'` — a numeric value entered once per match. The stored value is a nested object keyed by TBA match key (e.g. `{ "2026misjo_qm12": 5 }`).
+- An optional `readOnly?: boolean` flag — when true, the normal field input is rendered disabled.
+- An optional `derivedFromKey?: string` — the key of another field this one is computed from.
+- An optional `aggregation?: 'average'` — how to aggregate the source field (default `'average'`).
+
+The 2026 REBUILT adapter uses this to turn `auto_fuel_observed` and `teleop_fuel_observed` into read-only derived fields (`derivedFromKey` pointing to new `auto_fuel_matches` / `teleop_fuel_matches` per-match fields). EPA cross-references (`epaKey`) stay on the aggregate fields so downstream code (TeamCard, picklist) is unchanged.
+
+### Storage
+
+Per-match values live inside the existing `ScoutingNote.data` JSON blob under the per-match field's key. No Prisma migration, no new endpoint, no change to the PUT contract — consistent with ADR 033's JSON-blob design.
+
+### UI
+
+A new `PerMatchTable` component renders all per-match fields for a target team in a single table: rows are every match (qual and playoff) that target team is scheduled in, sorted via `sortMatches`; columns are Match label plus one numeric input per per-match field. The scouting form groups these fields in a dedicated "Per-Match Observations" section instead of their individual category blocks (auto/teleop).
+
+### Client-side aggregation
+
+`useScoutingData.updatePerMatchValue(fieldKey, matchKey, value)` updates the nested map and, if any field's `derivedFromKey` matches `fieldKey`, recomputes its value as the average of the remaining numeric entries (blanks excluded, rounded to 2 decimals) and writes that to the aggregate key. When the per-match map is empty, the legacy aggregate value is preserved — the first per-match edit overwrites it.
+
+## Alternatives Considered
+
+- **Add a new Prisma table for per-match scouting rows**. Rejected: would require a migration for every season's per-match schema shift and would fork the read/write paths from the rest of the scouting UI. The JSON-blob approach scales to arbitrary per-match fields with zero schema churn.
+- **Hardcode auton/teleop fuel in the UI**. Rejected: violates the GameDefinition adapter pattern (ADR 003). Other seasons could not reuse the mechanism without code changes.
+- **Server-side aggregation** (compute the average on PUT). Rejected: adds a server-side dependency on game-definition semantics, and the UI still needs the live-updating average for feedback. Client-side aggregation keeps the API a dumb JSON store and matches ADR 033's design.
+- **Only include qualification matches**. Rejected: playoff observations are equally useful for ranking and partner planning; the table filters by team-key membership so playoff rows simply appear as they're scheduled.
+
+## Consequences
+
+- Scouts enter raw counts; averages update live and are persisted alongside per-match data in the same PUT call.
+- Legacy notes with only aggregate values continue to render — the per-match map is simply empty and the legacy value remains untouched until the first per-match edit.
+- Any future season can opt in by declaring `type: 'per-match-number'` fields and marking an aggregate `readOnly` + `derivedFromKey`. No framework code changes needed.
+- The aggregate's `epaKey` link is still the single cross-reference into EPA analytics, so TeamCard / picklist / briefing consumers are unaffected.
+- Because aggregation is client-side, users on very old clients would not recompute averages; this is acceptable given the SWA auto-update model.
+
+## Relationship to ADR 033
+
+This ADR extends ADR 033 — it does not supersede it. The aggregate-per-team data model from ADR 033 is unchanged; this ADR only adds an optional per-match field type that lives inside the same `data` JSON blob.

--- a/packages/shared/src/adapters/2026-rebuilt.ts
+++ b/packages/shared/src/adapters/2026-rebuilt.ts
@@ -498,6 +498,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
       'Other',
     ],
     category: 'general',
+    showInTeamCard: true,
   },
   {
     key: 'tuning_practices',
@@ -531,6 +532,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
     type: 'multi-select',
     options: ['Neutral Zone', 'Own Alliance', 'Opposing Alliance', 'Defense Only', 'Last Resort'],
     category: 'general',
+    showInTeamCard: true,
   },
   {
     key: 'mechanical_issues',
@@ -539,6 +541,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
       'Describe any mechanical issues or breakdowns observed during the competition — jammed intakes, drivetrain failures, disconnects, broken mechanisms, etc. Note frequency and severity.',
     type: 'text',
     category: 'general',
+    showInTeamCard: true,
   },
   {
     key: 'practice_field_usage',
@@ -576,6 +579,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
     readOnly: true,
     derivedFromKey: 'auto_fuel_matches',
     aggregation: 'average',
+    showInTeamCard: true,
   },
   {
     key: 'auto_fuel_matches',
@@ -593,6 +597,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
     type: 'select',
     options: ['Yes', 'No'],
     category: 'auto',
+    showInTeamCard: true,
   },
   {
     key: 'preferred_auton_route',
@@ -626,6 +631,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
     readOnly: true,
     derivedFromKey: 'teleop_fuel_matches',
     aggregation: 'average',
+    showInTeamCard: true,
   },
   {
     key: 'teleop_fuel_matches',
@@ -643,6 +649,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
     type: 'multi-select',
     options: ['Neutral Zone', 'Alliance Zone'],
     category: 'teleop',
+    showInTeamCard: true,
   },
   {
     key: 'teleop_autonomous_actions',
@@ -671,6 +678,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
     options: ['Yes', 'No', 'Maybe'],
     category: 'endgame',
     epaKey: 'total_tower',
+    showInTeamCard: true,
   },
   {
     key: 'climb_level',
@@ -681,6 +689,7 @@ const scoutingFields: ScoutingFieldDefinition[] = [
     options: ['Level 1', 'Level 2', 'Level 3'],
     category: 'endgame',
     epaKey: 'total_tower',
+    showInTeamCard: true,
   },
   {
     key: 'endgame_strategy',

--- a/packages/shared/src/adapters/2026-rebuilt.ts
+++ b/packages/shared/src/adapters/2026-rebuilt.ts
@@ -532,6 +532,38 @@ const scoutingFields: ScoutingFieldDefinition[] = [
     options: ['Neutral Zone', 'Own Alliance', 'Opposing Alliance', 'Defense Only', 'Last Resort'],
     category: 'general',
   },
+  {
+    key: 'mechanical_issues',
+    label: 'Mechanical Issues / Breakdowns',
+    description:
+      'Describe any mechanical issues or breakdowns observed during the competition — jammed intakes, drivetrain failures, disconnects, broken mechanisms, etc. Note frequency and severity.',
+    type: 'text',
+    category: 'general',
+  },
+  {
+    key: 'practice_field_usage',
+    label: 'Practice Field Usage',
+    description:
+      "Ask the team whether they've used the practice field. If so, note how often they've been there and what they were testing or tuning. Capture specifics.",
+    type: 'text',
+    category: 'general',
+  },
+  {
+    key: 'practice_match_performance',
+    label: 'Practice Match Performance',
+    description:
+      'Note whether the team competed in any practice matches and, if so, how they performed — scoring, reliability, and any issues observed.',
+    type: 'text',
+    category: 'general',
+  },
+  {
+    key: 'social_media_presence',
+    label: 'Social Media Presence',
+    description:
+      'Record any social media presence (Chief Delphi, Instagram, X, YouTube, etc.) and anything noteworthy related to their performance or reputation.',
+    type: 'text',
+    category: 'general',
+  },
   // Auto
   {
     key: 'auto_fuel_observed',

--- a/packages/shared/src/adapters/2026-rebuilt.ts
+++ b/packages/shared/src/adapters/2026-rebuilt.ts
@@ -567,12 +567,23 @@ const scoutingFields: ScoutingFieldDefinition[] = [
   // Auto
   {
     key: 'auto_fuel_observed',
-    label: 'Auton # Fuel',
+    label: 'Auton # Fuel (avg)',
     description:
-      'Count the number of fuel pieces scored during autonomous. Watch closely — auton is fast and easy to miss.',
+      'Average fuel pieces scored during autonomous. Automatically computed from the per-match entries below — not directly editable.',
     type: 'number',
     category: 'auto',
     epaKey: 'auto_fuel',
+    readOnly: true,
+    derivedFromKey: 'auto_fuel_matches',
+    aggregation: 'average',
+  },
+  {
+    key: 'auto_fuel_matches',
+    label: 'Auton Fuel (per match)',
+    description:
+      'Fuel scored during autonomous for each match. Enter counts per match; the average updates automatically.',
+    type: 'per-match-number',
+    category: 'auto',
   },
   {
     key: 'drives_neutral',
@@ -606,12 +617,23 @@ const scoutingFields: ScoutingFieldDefinition[] = [
   // Teleop
   {
     key: 'teleop_fuel_observed',
-    label: '# of Fuel During Teleop',
+    label: '# of Fuel During Teleop (avg)',
     description:
-      'Average number of fuel pieces scored during teleop. Try to count across multiple matches for a reliable estimate.',
+      'Average fuel pieces scored during teleop. Automatically computed from the per-match entries below — not directly editable.',
     type: 'number',
     category: 'teleop',
     epaKey: 'teleop_fuel',
+    readOnly: true,
+    derivedFromKey: 'teleop_fuel_matches',
+    aggregation: 'average',
+  },
+  {
+    key: 'teleop_fuel_matches',
+    label: 'Teleop Fuel (per match)',
+    description:
+      'Fuel scored during teleop for each match. Enter counts per match; the average updates automatically.',
+    type: 'per-match-number',
+    category: 'teleop',
   },
   {
     key: 'fuel_source',

--- a/packages/shared/src/adapters/__tests__/2026-rebuilt.test.ts
+++ b/packages/shared/src/adapters/__tests__/2026-rebuilt.test.ts
@@ -247,10 +247,50 @@ describe('2026 REBUILT adapter', () => {
     });
 
     it('has field types that are valid', () => {
-      const validTypes = ['number', 'boolean', 'select', 'multi-select', 'text'];
+      const validTypes = [
+        'number',
+        'boolean',
+        'select',
+        'multi-select',
+        'text',
+        'per-match-number',
+      ];
       for (const f of fields) {
         expect(validTypes).toContain(f.type);
       }
+    });
+
+    describe('per-match fuel aggregation', () => {
+      it('marks auto_fuel_observed and teleop_fuel_observed as readOnly with derivedFromKey', () => {
+        const autoAvg = fields.find((f) => f.key === 'auto_fuel_observed');
+        const teleopAvg = fields.find((f) => f.key === 'teleop_fuel_observed');
+        expect(autoAvg).toBeDefined();
+        expect(teleopAvg).toBeDefined();
+        expect(autoAvg!.readOnly).toBe(true);
+        expect(teleopAvg!.readOnly).toBe(true);
+        expect(autoAvg!.derivedFromKey).toBe('auto_fuel_matches');
+        expect(teleopAvg!.derivedFromKey).toBe('teleop_fuel_matches');
+      });
+
+      it('declares matching per-match-number source fields', () => {
+        const autoMatches = fields.find((f) => f.key === 'auto_fuel_matches');
+        const teleopMatches = fields.find((f) => f.key === 'teleop_fuel_matches');
+        expect(autoMatches).toBeDefined();
+        expect(teleopMatches).toBeDefined();
+        expect(autoMatches!.type).toBe('per-match-number');
+        expect(teleopMatches!.type).toBe('per-match-number');
+        expect(autoMatches!.category).toBe('auto');
+        expect(teleopMatches!.category).toBe('teleop');
+      });
+
+      it('every derivedFromKey resolves to an existing field', () => {
+        const keys = new Set(fields.map((f) => f.key));
+        for (const f of fields) {
+          if (f.derivedFromKey) {
+            expect(keys.has(f.derivedFromKey)).toBe(true);
+          }
+        }
+      });
     });
   });
 });

--- a/packages/shared/src/types/game-definition.ts
+++ b/packages/shared/src/types/game-definition.ts
@@ -76,14 +76,37 @@ export interface ScoutingFieldDefinition {
   label: string;
   /** Tooltip or helper text */
   description: string;
-  /** Input type */
-  type: 'number' | 'boolean' | 'select' | 'multi-select' | 'text';
+  /**
+   * Input type.
+   *
+   * For `per-match-number`, the stored value is an object keyed by match key
+   * (e.g. `{ "2026misjo_qm12": 5 }`). These fields are rendered collectively in
+   * a per-match table rather than as an individual input.
+   */
+  type: 'number' | 'boolean' | 'select' | 'multi-select' | 'text' | 'per-match-number';
   /** Options for 'select' and 'multi-select' type fields */
   options?: string[];
   /** Phase/section grouping for form layout */
   category: 'general' | 'auto' | 'teleop' | 'endgame';
   /** Link to an EPA breakdown key (for cross-referencing observed vs computed) */
   epaKey?: string;
+  /**
+   * If true, the field is shown but not directly editable by the user.
+   * Typically used together with `derivedFromKey` to display a value computed
+   * client-side from another field (e.g. average of per-match entries).
+   */
+  readOnly?: boolean;
+  /**
+   * The key of another `ScoutingFieldDefinition` this field is derived from.
+   * When set, the scouting form recomputes this field's value whenever the
+   * referenced field changes (see `aggregation`).
+   */
+  derivedFromKey?: string;
+  /**
+   * How to aggregate the source field when this field is derived. Defaults to
+   * `'average'` when `derivedFromKey` is set. Blank entries are excluded.
+   */
+  aggregation?: 'average';
 }
 
 /** Per-season game definition adapter */

--- a/packages/shared/src/types/game-definition.ts
+++ b/packages/shared/src/types/game-definition.ts
@@ -107,6 +107,14 @@ export interface ScoutingFieldDefinition {
    * `'average'` when `derivedFromKey` is set. Blank entries are excluded.
    */
   aggregation?: 'average';
+  /**
+   * When true, surface this field in the quick-glance Scouting section of the
+   * team card. Intended for a small curated set of decision-driving fields;
+   * all fields remain available in the full scouting form regardless.
+   * `per-match-number` fields should generally keep this false and rely on
+   * their derived companion field for team-card display. Defaults to false.
+   */
+  showInTeamCard?: boolean;
 }
 
 /** Per-season game definition adapter */


### PR DESCRIPTION
## Summary

Rounds out the Scouting workflow ahead of Worlds with new fields, per-match observations, a team detail modal, and quality-of-life UI tweaks. Also tightens error telemetry for easier debugging.

## Changes

### Scouting
- **New fields** in the 2026 adapter: mechanical issues, practice field usage, practice match performance, social media presence.
- **Per-match observations** — new `per-match-number` scouting field type with dedicated table UI, automatic average aggregation, and unit tests. See ADR-034.
- **Team detail modal** on the scouting page for quick deep-dive without leaving the list, plus team records calculation.
- **`showInTeamCard`** flag on scouting fields — adapters can now surface select fields on the team card.
- **Collapse/Expand all** toggle on the scouting form (inline with the Notes label so it doesn't stagger the layout).

### Telemetry
- API telemetry now includes Prisma error codes and logs to stderr in non-production environments.

### Misc
- Minor app-header adjustments.